### PR TITLE
Sticky header and cols added to the Table components

### DIFF
--- a/src/components/layout/Table/cmp.stories.tsx
+++ b/src/components/layout/Table/cmp.stories.tsx
@@ -48,6 +48,36 @@ const dataArgs = {
       align: 'right',
     },
     {
+      label: 'Age',
+      render: (row: MockDataRow) => row.age,
+      sortable: true,
+      align: 'right',
+    },
+    {
+      label: 'Age',
+      render: (row: MockDataRow) => row.age,
+      sortable: true,
+      align: 'right',
+    },
+    {
+      label: 'Age',
+      render: (row: MockDataRow) => row.age,
+      sortable: true,
+      align: 'right',
+    },
+    {
+      label: 'Age',
+      render: (row: MockDataRow) => row.age,
+      sortable: true,
+      align: 'right',
+    },
+    {
+      label: 'Age',
+      render: (row: MockDataRow) => row.age,
+      sortable: true,
+      align: 'right',
+    },
+    {
       label: 'Job',
       render: (row: MockDataRow) => row.job,
       sortable: false,
@@ -66,6 +96,56 @@ const dataArgs = {
   ] as TableColumn<any>[],
 }
 
+const stickyDataArgs = {
+  data,
+  columns: [
+    {
+      label: 'Name',
+      sticky: 'start',
+      sortable: true,
+      width: '50%',
+      sortBy: (row: MockDataRow) => row.name,
+      render: (row: MockDataRow) => (
+        <div>
+          <strong>{row.name}</strong>
+          {row.gender !== 'undisclosed' && (
+            <>
+              &nbsp;
+              <Icon
+                name={row.gender === 'female' ? 'venus' : 'mars'}
+                color="red"
+              />
+            </>
+          )}
+        </div>
+      ),
+    },
+    {
+      label: 'Age',
+      render: (row: MockDataRow) => row.age,
+      sortable: true,
+      align: 'right',
+    },
+    {
+      label: 'Job',
+      render: (row: MockDataRow) => row.job,
+      sortable: false,
+      align: 'center',
+    },
+    {
+      label: 'Number of pets',
+      render: (row: MockDataRow) =>
+        Object.values(row.pets as Pets).reduce(
+          (acc: number, curr: number): number => acc + curr,
+          0,
+        ),
+      sortable: true,
+      align: 'right',
+      sticky: 'end',
+    },
+  ] as TableColumn<any>[],
+}
+
 const defaultArgs: TableProps<any> = {
   borderType: 'dashed' as TableBorderType,
   rowNoise: true,
@@ -75,6 +155,13 @@ const defaultArgs: TableProps<any> = {
       alert(`row click ${i}`)
     },
   }),
+}
+
+const stickyTableArgs: TableProps<any> = {
+  stickyHeader: true,
+  borderType: 'dashed' as TableBorderType,
+  rowNoise: true,
+  ...stickyDataArgs,
 }
 
 const defaultParams = {
@@ -91,4 +178,9 @@ Default.args = {
 }
 Default.parameters = {
   ...defaultParams,
+}
+
+export const StickyTable = Template.bind({})
+StickyTable.args = {
+  ...stickyTableArgs,
 }

--- a/src/components/layout/Table/cmp.tsx
+++ b/src/components/layout/Table/cmp.tsx
@@ -79,6 +79,7 @@ function Cell<R extends Record<string, unknown>>({
 
 function HeaderCell<R extends Record<string, unknown>>({
   col,
+  sticky,
   colIndex,
   sortedColumn,
   setSortedColumn,
@@ -119,7 +120,7 @@ function HeaderCell<R extends Record<string, unknown>>({
         <th
           key={colIndex}
           {...props}
-          css={props.css}
+          css={[props.css, sticky && tw`sticky top-0`]}
           style={props.style}
           onClick={() => {
             if (!col.sortable) return
@@ -211,6 +212,7 @@ export function Table<R extends Record<string, unknown>>(props: TableProps<R>) {
         <tr>
           {columns.map((col, colIndex) => (
             <HeaderCell
+              sticky={props.stickyHeader}
               key={colIndex}
               {...{
                 col,

--- a/src/components/layout/Table/cmp.tsx
+++ b/src/components/layout/Table/cmp.tsx
@@ -15,6 +15,7 @@ function Row<R extends Record<string, unknown>>({
   rowIndex,
   rowRender,
   rowProps,
+  sticky,
   rowNoise = false,
 }: TableRowProps<R>) {
   const props = useMemo(() => {
@@ -32,6 +33,7 @@ function Row<R extends Record<string, unknown>>({
             <Cell
               key={colIndex}
               {...{ row, col, rowIndex, colIndex, rowNoise }}
+              sticky={sticky} // Pass the sticky prop
             />
           ))}
         </tr>
@@ -46,7 +48,8 @@ function Cell<R extends Record<string, unknown>>({
   rowIndex,
   colIndex,
   rowNoise,
-}: TableCellProps<R>) {
+  sticky, // New prop to determine if the column should be sticky
+}: TableCellProps<R> & { sticky?: boolean }) {
   const alignStyle = useMemo(() => {
     return col.align === 'center'
       ? tw`text-center`
@@ -69,7 +72,11 @@ function Cell<R extends Record<string, unknown>>({
       {col.cellRender ? (
         col.cellRender(row, col, rowIndex, colIndex)
       ) : (
-        <td key={colIndex} {...props} css={props.css}>
+        <td
+          key={colIndex}
+          {...props}
+          css={[props.css, sticky && tw`sticky left-0`]} // Apply sticky styles conditionally
+        >
           {col.render(row, col, rowIndex, colIndex)}
         </td>
       )}
@@ -227,6 +234,7 @@ export function Table<R extends Record<string, unknown>>(props: TableProps<R>) {
       <tbody>
         {sortedData.map((row, rowIndex) => (
           <Row
+            sticky={props.stickyColumn}
             key={row.key}
             {...{
               row,

--- a/src/components/layout/Table/fixture/data.ts
+++ b/src/components/layout/Table/fixture/data.ts
@@ -46,6 +46,83 @@ export const data: MockDataRow[] = [
     },
     gender: 'female',
   },
+  {
+    name: 'Michael Johnson',
+    age: 35,
+    job: 'Data Scientist',
+    pets: {
+      dogs: 2,
+      cats: 3,
+      turtles: 1,
+    },
+    gender: 'male',
+  },
+  {
+    name: 'Sarah Brown',
+    age: 22,
+    job: 'UX Designer',
+    pets: {
+      dogs: 1,
+      cats: 1,
+      turtles: 0,
+    },
+    gender: 'female',
+  },
+  {
+    name: 'David Wilson',
+    age: 40,
+    job: 'Project Manager',
+    pets: {
+      dogs: 3,
+      cats: 2,
+      turtles: 2,
+    },
+    gender: 'male',
+  },
+  {
+    name: 'Olivia Davis',
+    age: 27,
+    job: 'Marketing Specialist',
+    pets: {
+      dogs: 1,
+      cats: 0,
+      turtles: 3,
+    },
+    gender: 'female',
+  },
+  {
+    name: 'Chris Miller',
+    age: 32,
+    job: 'Frontend Developer',
+    pets: {
+      dogs: 2,
+      cats: 1,
+      turtles: 1,
+    },
+    gender: 'male',
+  },
+  {
+    name: 'Ella Turner',
+    age: 29,
+    job: 'Graphic Designer',
+    pets: {
+      dogs: 0,
+      cats: 2,
+      turtles: 0,
+    },
+    gender: 'female',
+  },
+  {
+    name: 'Alex Harris',
+    age: 34,
+    job: 'Sales Manager',
+    pets: {
+      dogs: 1,
+      cats: 0,
+      turtles: 4,
+    },
+    gender: 'male',
+  },
 ]
 
 export type Pets = {

--- a/src/components/layout/Table/types.ts
+++ b/src/components/layout/Table/types.ts
@@ -7,6 +7,7 @@ import {
 
 export type TableBorderType = 'none' | 'dashed' | 'solid'
 export type TableAlignType = 'left' | 'center' | 'right'
+export type TableStickyPosition = 'start' | 'end'
 
 export type TableRow<R extends Record<string, unknown>> = {
   rowRender?: (row: R, rowIndex: number) => ReactNode
@@ -19,6 +20,7 @@ export type TableColumn<R extends Record<string, unknown>> = {
   sortable?: boolean
   align?: TableAlignType
   width?: string
+  sticky?: TableStickyPosition
   cellRender?: (
     row: R,
     col: TableColumn<R>,
@@ -63,7 +65,6 @@ export type TableProps<R extends Record<string, unknown>> =
       columns: TableColumn<R>[]
       data: R[]
       stickyHeader: boolean
-      stickyColumn: boolean
       borderType: TableBorderType
       rowNoise?: boolean
     }
@@ -75,7 +76,6 @@ export type TableRowProps<R extends Record<string, unknown>> =
       columns: TableColumn<R>[]
       rowIndex: number
       rowNoise?: boolean
-      sticky: boolean
     }
 
 export type TableCellProps<R extends Record<string, unknown>> =
@@ -91,7 +91,6 @@ export type TableSortedColumn = { column: string; asc: boolean }
 
 export type TableHeaderCellProps<R extends Record<string, unknown>> =
   TdHTMLAttributes<HTMLTableCellElement> & {
-    sticky: boolean
     col: TableColumn<R>
     colIndex: number
     sortedColumn: TableSortedColumn

--- a/src/components/layout/Table/types.ts
+++ b/src/components/layout/Table/types.ts
@@ -63,6 +63,7 @@ export type TableProps<R extends Record<string, unknown>> =
       columns: TableColumn<R>[]
       data: R[]
       stickyHeader: boolean
+      stickyColumn: boolean
       borderType: TableBorderType
       rowNoise?: boolean
     }
@@ -74,6 +75,7 @@ export type TableRowProps<R extends Record<string, unknown>> =
       columns: TableColumn<R>[]
       rowIndex: number
       rowNoise?: boolean
+      sticky: boolean
     }
 
 export type TableCellProps<R extends Record<string, unknown>> =

--- a/src/components/layout/Table/types.ts
+++ b/src/components/layout/Table/types.ts
@@ -62,6 +62,7 @@ export type TableProps<R extends Record<string, unknown>> =
     TableRow<R> & {
       columns: TableColumn<R>[]
       data: R[]
+      stickyHeader: boolean
       borderType: TableBorderType
       rowNoise?: boolean
     }
@@ -88,6 +89,7 @@ export type TableSortedColumn = { column: string; asc: boolean }
 
 export type TableHeaderCellProps<R extends Record<string, unknown>> =
   TdHTMLAttributes<HTMLTableCellElement> & {
+    sticky: boolean
     col: TableColumn<R>
     colIndex: number
     sortedColumn: TableSortedColumn


### PR DESCRIPTION
### Description

This pull request introduces a new feature to the Table component, allowing users to make specific header rows sticky and choose the stickiness of individual columns.

### Changes Made

1. **Sticky Header for Specific Rows:**
   - Added a `stickyHeader` prop to `TableProps`.
   - Users can pass `stickyHeader` as a boolean to make the header row sticky when scrolling.
  
2. **Sticky Columns:**
   - Added a `sticky` property to each column definition in the `col` array.
   - Users can set the `sticky` property to either `'start'` or `'end'` to make a column sticky on the left or right side, respectively.

### Example Usage

```jsx
<Table
  data={yourData}
  columns={[
    { header: 'Name', accessor: 'name', sticky: 'start' },
    { header: 'Age', accessor: 'age' },
    { header: 'Job', accessor: 'job' },
    // ...
  ]}
  stickyHeader={true}
/>


### Additional Notes
The sticky property for columns enhances the flexibility of the Table component.
The stickyHeader prop provides a convenient way to make the header row sticky when needed.
Ensure that styling is consistent and visually appealing when using sticky headers and columns.

